### PR TITLE
PRJDM-2334/rename default login event

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,6 +15,8 @@
 homepage: "https://github.com/zeotap/zeocollect-gtm-template"
 documentation: "https://github.com/zeotap/zeocollect-gtm-template"
 versions:
+  - sha: 8d8adbe2e6ad76f0f38e2048c1c2580c27c79340
+    changeNotes: Rename default loginEvent name
   - sha: 8bfaa11a50911662d033bc5bbf00b4d28c2d4be5
     changeNotes: Update Template for Google Analytics Integration
   - sha: 7956c0ad71b2402ea7af27b7c63387b373f5cf58

--- a/template.tpl
+++ b/template.tpl
@@ -215,7 +215,7 @@ ___TEMPLATE_PARAMETERS___
             "displayName": "Login Event",
             "simpleValueType": true,
             "help": "Specify the dataLayer event fired on user login",
-            "defaultValue": "event"
+            "defaultValue": "login"
           },
           {
             "type": "CHECKBOX",


### PR DESCRIPTION
This is for the resolution of Collect GTM Integration with BillionHands. (detail: https://zeotap.atlassian.net/browse/PRJDM-2334)
Due to the default login event named earlier as "event" multiple login events are getting triggered on publisher's end.